### PR TITLE
Allow running the app without MySQL

### DIFF
--- a/Paqueteria/README.md
+++ b/Paqueteria/README.md
@@ -5,7 +5,7 @@ Proyecto de ejemplo para gestionar clientes, paquetes y envíos usando Spring Bo
 Requisitos
 - Java 17+
 - Maven
-- MySQL (base de datos `paqueteria`)
+- (Opcional) MySQL si deseas usar la base de datos externa
 
 Nota: Si `mvn` no está instalado en tu máquina, instala Maven o usa tu IDE (IntelliJ/Eclipse) para importar el proyecto como Maven.
 
@@ -21,15 +21,15 @@ GRANT ALL PRIVILEGES ON paqueteria.* TO 'default'@'localhost';
 FLUSH PRIVILEGES;
 ```
 
-2. El archivo `src/main/resources/application.properties` está configurado con:
+2. Por defecto el proyecto usa una base de datos en memoria H2 para facilitar la ejecución sin dependencias externas.
 
-- host: localhost
-- puerto: 3306
-- base de datos: paqueteria
-- usuario: `default`
-- contraseña: `m@teo123`
+Si prefieres conectar un MySQL local, crea la base de datos y ejecuta con el perfil `mysql`:
 
-Si usas otro usuario/contraseña, actualiza `application.properties`.
+```bash
+mvn spring-boot:run -Dspring-boot.run.profiles=mysql
+```
+
+El archivo `src/main/resources/application-mysql.properties` contiene la configuración por defecto (host `localhost`, base `paqueteria`, usuario `default`, contraseña `m@teo123`). Ajusta esos valores si necesitas otras credenciales.
 
 Construir y ejecutar
 

--- a/Paqueteria/pom.xml
+++ b/Paqueteria/pom.xml
@@ -45,6 +45,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>

--- a/Paqueteria/src/main/java/com/paqueteria/controller/EnvioController.java
+++ b/Paqueteria/src/main/java/com/paqueteria/controller/EnvioController.java
@@ -53,22 +53,37 @@ public class EnvioController {
 
     @PutMapping("/{id}")
     public ResponseEntity<?> update(@PathVariable Long id, @Valid @RequestBody Envio envio) {
-        return repo.findById(id).map(existing -> {
-            if (envio.getCliente() != null && envio.getCliente().getId() != null) {
-                Cliente c = clienteRepo.findById(envio.getCliente().getId()).orElse(null);
-                if (c == null) return ResponseEntity.badRequest().body("cliente no encontrado");
-                existing.setCliente(c);
+        Envio existing = repo.findById(id).orElse(null);
+        if (existing == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        if (envio.getCliente() != null && envio.getCliente().getId() != null) {
+            Cliente c = clienteRepo.findById(envio.getCliente().getId()).orElse(null);
+            if (c == null) {
+                return ResponseEntity.badRequest().body("cliente no encontrado");
             }
-            if (envio.getPaquete() != null && envio.getPaquete().getId() != null) {
-                Paquete p = paqueteRepo.findById(envio.getPaquete().getId()).orElse(null);
-                if (p == null) return ResponseEntity.badRequest().body("paquete no encontrado");
-                existing.setPaquete(p);
+            existing.setCliente(c);
+        }
+
+        if (envio.getPaquete() != null && envio.getPaquete().getId() != null) {
+            Paquete p = paqueteRepo.findById(envio.getPaquete().getId()).orElse(null);
+            if (p == null) {
+                return ResponseEntity.badRequest().body("paquete no encontrado");
             }
-            existing.setFechaRegistro(envio.getFechaRegistro() != null ? envio.getFechaRegistro() : existing.getFechaRegistro());
+            existing.setPaquete(p);
+        }
+
+        if (envio.getFechaRegistro() != null) {
+            existing.setFechaRegistro(envio.getFechaRegistro());
+        }
+
+        if (envio.getCosto() != null) {
             existing.setCosto(envio.getCosto());
-            repo.save(existing);
-            return ResponseEntity.ok(existing);
-        }).orElse(ResponseEntity.notFound().build());
+        }
+
+        Envio saved = repo.save(existing);
+        return ResponseEntity.ok(saved);
     }
 
     @DeleteMapping("/{id}")

--- a/Paqueteria/src/main/resources/application-mysql.properties
+++ b/Paqueteria/src/main/resources/application-mysql.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:mysql://localhost:3306/paqueteria?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+spring.datasource.username=default
+spring.datasource.password=m@teo123
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true

--- a/Paqueteria/src/main/resources/application.properties
+++ b/Paqueteria/src/main/resources/application.properties
@@ -1,6 +1,11 @@
-spring.datasource.url=jdbc:mysql://localhost:3306/paqueteria?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
-spring.datasource.username=default
-spring.datasource.password=m@teo123
+# Base de datos en memoria para facilitar la ejecución local sin MySQL
+spring.datasource.url=jdbc:h2:mem:paqueteria;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.h2.console.enabled=true
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
## Summary
- add an in-memory H2 datasource so the application can start without an external database
- keep the original MySQL settings under a dedicated Spring profile and document how to use it
- simplify envio update logic to avoid nested optional handling when editing related entities

## Testing
- `mvn -q -e -DskipTests spring-boot:run` *(fails: Maven Central returns HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e049f4d664832a824f113f54ae359d